### PR TITLE
Fixed issue with periods in file name

### DIFF
--- a/html2image/html2image.py
+++ b/html2image/html2image.py
@@ -510,7 +510,7 @@ class Html2Image():
             name = save_as.pop(0)
             current_size = size.pop(0)
 
-            html_filename = name.split('.')[0] + '.html'
+            html_filename = ''.join(name.split('.')[:-1]) + '.html'
             content = Html2Image._prepare_html_string(
                 html, css_style_string
             )


### PR DESCRIPTION
If you have a file name that has a period in it (which is valid) the code splits on the first period. This change updates the code to split only on the last period and keep the former, if there exist any.